### PR TITLE
Close portfolio menu on navigation

### DIFF
--- a/apps/daily/src/app/api/[month]/[day]/route.ts
+++ b/apps/daily/src/app/api/[month]/[day]/route.ts
@@ -1,7 +1,11 @@
 import { getDaily, isValidDate } from "@/lib/content";
 import { tryCatch } from "@/lib/utils";
 
-export async function GET(_: Request, ctx: RouteContext<"/api/[month]/[day]">) {
+type Params = {
+  params: Promise<{ month: string; day: string }>;
+};
+
+export async function GET(_: Request, ctx: Params) {
   const { month, day } = await ctx.params;
 
   // Validate against the known content set before importing, and keep the 404

--- a/apps/portfolio-v2/src/components/Menu/Menu.tsx
+++ b/apps/portfolio-v2/src/components/Menu/Menu.tsx
@@ -110,7 +110,7 @@ export function Menu() {
 									}}
 									variants={panelVariants}
 								>
-									<MenuPanel />
+									<MenuPanel onNavigate={() => setOpen(false)} />
 								</motion.div>
 							</PopoverPrimitive.Content>
 						</PopoverPrimitive.Portal>

--- a/apps/portfolio-v2/src/components/Menu/MenuPanel.tsx
+++ b/apps/portfolio-v2/src/components/Menu/MenuPanel.tsx
@@ -14,10 +14,10 @@ import { GITHUB, LINKED_IN } from "@/utils/constants";
 import ContactDialog from "../Contact/ContactDialog";
 import styles from "./styles.module.css";
 
-export function MenuPanel() {
+export function MenuPanel({ onNavigate }: { onNavigate: () => void }) {
 	return (
 		<div className="mt-10 flex flex-col gap-8">
-			<Nav />
+			<Nav onNavigate={onNavigate} />
 
 			<div>
 				<h4 className="mb-3 text-gray10 dark:text-gray11">Connect</h4>
@@ -139,13 +139,13 @@ const links: Array<{
 	{ href: "/work", label: "Work", color: "bg-accent-violet" },
 ];
 
-function Nav() {
+function Nav({ onNavigate }: { onNavigate: () => void }) {
 	return (
 		<nav>
 			<ul className="flex flex-col">
 				{links.map((link) => (
 					<li key={link.label}>
-						<a className="font-medium" href={link.href}>
+						<a className="font-medium" href={link.href} onClick={onNavigate}>
 							<MenuItem
 								Icon={
 									<ArrowRight


### PR DESCRIPTION
## Summary
- Close the persisted portfolio menu when internal menu nav links are clicked
- Pass a navigation callback from the menu owner into the menu panel/nav links

## Verification
- pnpm --filter portfolio-2.0 typecheck
- Manually verified in dev server: opening the menu and clicking Notes closes the menu during navigation